### PR TITLE
Add three.js and skeleton for interactive projects page

### DIFF
--- a/package.json
+++ b/package.json
@@ -9,7 +9,11 @@
   },
   "dependencies": {
     "react": "^18.2.0",
-    "react-dom": "^18.2.0"
+    "react-dom": "^18.2.0",
+    "three": "^0.156.1",
+    "@react-three/fiber": "^8.12.1",
+    "@react-three/drei": "^9.60.5",
+    "framer-motion": "^10.12.16"
   },
   "devDependencies": {
     "@types/react": "^18.0.28",

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useRef } from "react";
 import LandingPage from "./pages/LandingPage";
+import ProjectsPage from "./pages/ProjectsPage";
 import NavBar       from "./components/NavBar/NavBar";
 import TransitionWipe, {
   TransitionHandle,
@@ -47,6 +48,8 @@ function App() {
       {/* main content */}
       {page === "landing" ? (
         <LandingPage onNavigate={handleNavigate} />
+      ) : page === "My Projects" ? (
+        <ProjectsPage />
       ) : (
         <div className="w-full h-full flex items-center justify-center bg-white">
           <h1 className="text-4xl">{page} Page</h1>

--- a/src/components/Projects/CardScene.tsx
+++ b/src/components/Projects/CardScene.tsx
@@ -1,0 +1,27 @@
+import React, { useRef } from "react";
+import { useFrame } from "@react-three/fiber";
+
+const SpinningBox: React.FC = () => {
+  const ref = useRef<any>(null);
+  useFrame((_, delta) => {
+    if (ref.current) {
+      ref.current.rotation.y += delta;
+      ref.current.rotation.x += delta / 2;
+    }
+  });
+  return (
+    <mesh ref={ref}>
+      <boxGeometry args={[1, 1, 1]} />
+      <meshStandardMaterial color="#ffa500" />
+    </mesh>
+  );
+};
+
+const CardScene: React.FC = () => (
+  <>
+    <ambientLight intensity={0.5} />
+    <SpinningBox />
+  </>
+);
+
+export default CardScene;

--- a/src/components/Projects/IntroShuffle.tsx
+++ b/src/components/Projects/IntroShuffle.tsx
@@ -1,0 +1,22 @@
+import React from "react";
+import { motion } from "framer-motion";
+
+const IntroShuffle: React.FC = () => {
+  const cards = Array.from({ length: 5 });
+
+  return (
+    <div className="absolute inset-0 flex items-center justify-center pointer-events-none">
+      {cards.map((_, idx) => (
+        <motion.div
+          key={idx}
+          initial={{ rotate: 0, scale: 0.5, opacity: 0 }}
+          animate={{ rotate: 360, scale: 1, opacity: 1 }}
+          transition={{ duration: 1, delay: idx * 0.2 }}
+          className="w-32 h-48 bg-gray-200 rounded-lg shadow-lg m-1"
+        />
+      ))}
+    </div>
+  );
+};
+
+export default IntroShuffle;

--- a/src/components/Projects/ProjectCard.tsx
+++ b/src/components/Projects/ProjectCard.tsx
@@ -1,0 +1,30 @@
+import React, { useRef } from "react";
+import { Canvas } from "@react-three/fiber";
+import { motion, useScroll, useTransform } from "framer-motion";
+import CardScene from "./CardScene";
+
+export interface ProjectCardProps {
+  index: number;
+  title: string;
+}
+
+const ProjectCard: React.FC<ProjectCardProps> = ({ index, title }) => {
+  const ref = useRef<HTMLDivElement>(null);
+  const { scrollYProgress } = useScroll({ target: ref, offset: ["start end", "end start"] });
+  const rotateY = useTransform(scrollYProgress, [0, 1], [0, 180]);
+
+  return (
+    <section ref={ref} className="h-screen flex items-center justify-center">
+      <motion.div
+        style={{ rotateY }}
+        className="w-64 h-96 bg-white rounded-lg shadow-xl flex items-center justify-center"
+      >
+        <Canvas className="w-full h-full">
+          <CardScene />
+        </Canvas>
+      </motion.div>
+    </section>
+  );
+};
+
+export default ProjectCard;

--- a/src/components/Projects/ProjectScroller.tsx
+++ b/src/components/Projects/ProjectScroller.tsx
@@ -1,0 +1,16 @@
+import React from "react";
+import ProjectCard from "./ProjectCard";
+
+const sampleProjects = ["First Project", "Second Project", "Third Project"];
+
+const ProjectScroller: React.FC = () => {
+  return (
+    <div className="w-screen h-auto overflow-y-auto">
+      {sampleProjects.map((title, idx) => (
+        <ProjectCard key={idx} index={idx} title={title} />
+      ))}
+    </div>
+  );
+};
+
+export default ProjectScroller;

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,0 +1,18 @@
+import React, { useState } from "react";
+import IntroShuffle from "../components/Projects/IntroShuffle";
+import ProjectScroller from "../components/Projects/ProjectScroller";
+
+const ProjectsPage: React.FC = () => {
+  const [showIntro, setShowIntro] = useState(true);
+
+  return (
+    <div className="relative w-screen h-screen overflow-y-auto bg-white">
+      {showIntro && (
+        <IntroShuffle />
+      )}
+      <ProjectScroller />
+    </div>
+  );
+};
+
+export default ProjectsPage;


### PR DESCRIPTION
## Summary
- add three.js related libraries and framer-motion to package.json
- implement `ProjectsPage` with placeholder intro and scroll components
- add `ProjectCard`, `CardScene`, `IntroShuffle`, and `ProjectScroller` components
- update `App` to render `ProjectsPage`

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_68534df52dfc833194b73632d7ae11f8