### PR TITLE
Fix project page components

### DIFF
--- a/src/assets.d.ts
+++ b/src/assets.d.ts
@@ -1,0 +1,4 @@
+declare module '*.png' {
+  const src: string;
+  export default src;
+}

--- a/src/components/Projects/Card3D.tsx
+++ b/src/components/Projects/Card3D.tsx
@@ -5,8 +5,13 @@ import { useTexture } from "@react-three/drei";
 import { MotionValue } from "framer-motion";
 import * as THREE from "three";
 
+import frontPlaceholder from "./textures/fronttemp.png";
+import backPlaceholder from "./textures/backtemp.png";
+
 /* ───────────────────────────── Types */
-export interface Card3DProps {
+type GroupProps = ThreeElements['group'];
+
+export interface Card3DProps extends GroupProps {
   frontSrc?: string;          // texture url (can be data-url)
   backSrc?:  string;
   width?:    number;          // world units
@@ -33,12 +38,13 @@ const Card3D: React.FC<Card3DProps> = ({
   pop,
   popScale = 1.15,
   onClick,
+  ...rest
 }) => {
   const group = useRef<THREE.Group>(null);
 
   /* textures (lazy) */
-  const [frontMap] = useTexture([frontSrc ?? "/textures/front-placeholder.png"]);
-  const [backMap]  = useTexture([backSrc  ?? "/textures/back-placeholder.png"]);
+  const [frontMap] = useTexture([frontSrc ?? frontPlaceholder]);
+  const [backMap]  = useTexture([backSrc  ?? backPlaceholder]);
 
   /* animation on every frame (cheap) */
   useFrame(() => {
@@ -57,7 +63,7 @@ const Card3D: React.FC<Card3DProps> = ({
 
   /* ───────────────────────────── Render */
   return (
-    <group ref={group} onClick={onClick}>
+    <group ref={group} onClick={onClick} {...rest}>
       {/* subtle bevel: thin box for the rim */}
       <mesh>
         <boxGeometry args={[width, height, thickness]} />

--- a/src/components/Projects/IntroDeck.tsx
+++ b/src/components/Projects/IntroDeck.tsx
@@ -2,6 +2,8 @@
 import React, { useMemo } from "react";
 import { MotionValue, useTransform } from "framer-motion";
 import Card3D from "./Card3D";
+import frontPlaceholder from "./textures/fronttemp.png";
+import backPlaceholder from "./textures/backtemp.png";
 
 interface IntroDeckProps {
   progress: MotionValue<number>; // local 0‒1
@@ -53,8 +55,8 @@ const IntroDeck: React.FC<IntroDeckProps> = ({
             flip={flipMv}
             pop={fanProg}        // small scale-up while fanning
             onClick={() => null}
-            frontSrc={"/textures/fronttemp.png"}
-            backSrc={"/textures/backtemp.png"}
+            frontSrc={frontPlaceholder}
+            backSrc={backPlaceholder}
             /* Three-JS style prop spread */
             position-x={fanX}
             position-y={fanY}

--- a/src/components/Projects/ProjectCardInfo.tsx
+++ b/src/components/Projects/ProjectCardInfo.tsx
@@ -2,7 +2,9 @@
 import React, { useMemo } from "react";
 import { MotionValue, useTransform, useSpring } from "framer-motion";
 import Card3D from "./Card3D";
- import { Html } from "@react-three/drei"; 
+import { Html } from "@react-three/drei";
+import frontPlaceholder from "./textures/fronttemp.png";
+import backPlaceholder from "./textures/backtemp.png";
 
 interface InfoCard {
   id: string;
@@ -21,8 +23,8 @@ interface ProjectCardInfoProps {
 const sampleInfo: InfoCard[] = [
   {
     id: "a",
-    front: "/textures/front-placeholder.png",
-    back: "/textures/back-placeholder.png",
+    front: frontPlaceholder,
+    back: backPlaceholder,
     title: "First Project",
     description: "Lorem ipsum dolor sit amet.",
   },

--- a/src/components/Projects/ProjectDeck.tsx
+++ b/src/components/Projects/ProjectDeck.tsx
@@ -2,6 +2,8 @@
 import React from "react";
 import { MotionValue, useTransform } from "framer-motion";
 import Card3D from "./Card3D";
+import frontPlaceholder from "./textures/fronttemp.png";
+import backPlaceholder from "./textures/backtemp.png";
 
 interface ProjectMeta {
   id: string;
@@ -17,9 +19,9 @@ interface ProjectDeckProps {
 }
 
 const sampleProjects: ProjectMeta[] = [
-  { id: "a", front: "/textures/fronttemp.png", back: "//textures/backtemp.png" },
-  { id: "b", front: "/textures/fronttemp.png", back: "/textures/backtemp.png" },
-  { id: "c", front: "/textures/fronttemp.png", back: "/textures/backtemp.png" },
+  { id: "a", front: frontPlaceholder, back: backPlaceholder },
+  { id: "b", front: frontPlaceholder, back: backPlaceholder },
+  { id: "c", front: frontPlaceholder, back: backPlaceholder },
 ];
 
 const ProjectDeck: React.FC<ProjectDeckProps> = ({

--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -1,7 +1,7 @@
 // src/components/Projects/ProjectStoryboard.tsx
 import React, { useRef } from "react";
 import { Canvas } from "@react-three/fiber";
-import { MotionValue, useScroll, useTransform, useMotionValue } from "framer-motion";
+import { MotionValue, useScroll, useTransform } from "framer-motion";
 import IntroDeck from "./IntroDeck";
 import SpreadReveal from "./SpreadReveal";
 import ProjectDeck from "./ProjectDeck";
@@ -49,6 +49,7 @@ const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({
       className="fixed inset-0 z-10 pointer-events-none"
       camera={{ position: [0, 0, 5], fov: 45 }}
     >
+      <ambientLight intensity={0.6} />
       {/* Scene 0 */}
       <IntroDeck progress={s0} />
 

--- a/src/components/Projects/SpreadReveal.tsx
+++ b/src/components/Projects/SpreadReveal.tsx
@@ -2,6 +2,8 @@
 import React from "react";
 import { MotionValue, useTransform } from "framer-motion";
 import Card3D from "./Card3D";
+import frontPlaceholder from "./textures/fronttemp.png";
+import backPlaceholder from "./textures/backtemp.png";
 
 interface SpreadRevealProps {
   progress: MotionValue<number>;
@@ -14,8 +16,8 @@ interface SpreadRevealProps {
 }
 
 const defaultCards = [...Array(5)].map((_, i) => ({
-  front: "/textures/fronttemp.png",
-  back:  "/textures/backtemp.png",
+  front: frontPlaceholder,
+  back:  backPlaceholder,
   elementScale: 1.2 + i * 0.05,
 }));
 


### PR DESCRIPTION
## Summary
- fix project page cards by passing group props through Card3D
- use imported textures for default assets
- add ambient light to the 3D storyboard
- declare PNG modules for TypeScript

## Testing
- `npx tsc --noEmit`
- `npm run build` *(fails: "You installed esbuild for another platform")*

------
https://chatgpt.com/codex/tasks/task_e_6859ac283f048331ae7e3513bad882cf