### PR TITLE
Fix scroll track for projects and autoplay first scene

### DIFF
--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -1,5 +1,5 @@
 // src/components/Projects/ProjectStoryboard.tsx
-import React, { useRef } from "react";
+import React, { useRef, useEffect } from "react";
 import { Canvas } from "@react-three/fiber";
 import { MotionValue, useScroll, useTransform } from "framer-motion";
 import IntroDeck from "./IntroDeck";
@@ -28,6 +28,7 @@ export interface ProjectStoryboardProps {
 const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({
   scrollContainer,
   sectionBreaks = [0.15, 0.30, 0.60, 1.0],
+  autoScrollDelay = 500,
 }) => {
   /* global scroll */
   const { scrollYProgress } = useScroll({
@@ -42,6 +43,17 @@ const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({
     slice(scrollYProgress, [sectionBreaks[1], sectionBreaks[2]]),
     slice(scrollYProgress, [sectionBreaks[2], sectionBreaks[3]]),
   ];
+
+  /* Kick off intro animation by scrolling to first section */
+  useEffect(() => {
+    const el = scrollContainer?.current;
+    if (!el) return;
+    const timer = setTimeout(() => {
+      const target = el.scrollHeight * sectionBreaks[0];
+      el.scrollTo({ top: target, behavior: "smooth" });
+    }, autoScrollDelay);
+    return () => clearTimeout(timer);
+  }, [scrollContainer, sectionBreaks, autoScrollDelay]);
 
   /* ───────────────────────────── Render */
   return (

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -11,8 +11,10 @@ const ProjectsPage: React.FC = () => {
       ref={scrollRef}
       className="relative w-screen h-screen overflow-y-auto bg-white"
     >
-      {/* all 3-D & animation lives in the storyboard */}
-      <ProjectStoryboard scrollContainer={scrollRef} />
+      {/* scroll track provides enough space for storyboard scenes */}
+      <div className="relative h-[400vh]">
+        <ProjectStoryboard scrollContainer={scrollRef} />
+      </div>
 
       {/* you can stack regular HTML content below if desired */}
       <Footer scrollContainerRef={scrollRef} />


### PR DESCRIPTION
## Summary
- extend the Projects page with a long scroll track so scenes can animate
- auto-scroll the storyboard to the first section to kick off the intro

## Testing
- `npm run build` *(fails: platform-specific esbuild binary)*

------
https://chatgpt.com/codex/tasks/task_e_6859b280e7dc83318ffb82948b9b2dc8