### PR TITLE
Fix angle calculation and JSX structure

### DIFF
--- a/src/components/Projects/IntroDeck.tsx
+++ b/src/components/Projects/IntroDeck.tsx
@@ -66,6 +66,7 @@ const IntroDeck: React.FC<IntroDeckProps> = ({
       const g = groupRefs.current[idx];
       if (!g) return;
 
+      const angle = (idx / cards.length) * Math.PI * 2;
 
       const off = shuffleOffsets[idx];
       const targetIndex = shuffleOrder[idx];
@@ -94,19 +95,19 @@ const IntroDeck: React.FC<IntroDeckProps> = ({
     )}'/></svg>`;
 
   return (
-
-    <IntroShuffle />
-
-    <group ref={deckRef}>
-      {cards.map((idx) => (
-        <group key={idx} ref={(el) => (groupRefs.current[idx] = el!)}>
-          <Card3D
-            frontSrc={colorTex(colors[idx % colors.length])}
-            backSrc={undefined}
-          />
-        </group>
-      ))}
-    </group>
+    <>
+      <IntroShuffle progress={progress} cardCount={cardCount} />
+      <group ref={deckRef}>
+        {cards.map((idx) => (
+          <group key={idx} ref={(el) => (groupRefs.current[idx] = el!)}>
+            <Card3D
+              frontSrc={colorTex(colors[idx % colors.length])}
+              backSrc={undefined}
+            />
+          </group>
+        ))}
+      </group>
+    </>
   );
 };
 

--- a/src/components/Projects/SpreadReveal.tsx
+++ b/src/components/Projects/SpreadReveal.tsx
@@ -20,7 +20,6 @@ const colorTex = (c: string) =>
 
 const defaultCards = Array.from({ length: 6 }, (_, i) => ({
   front: colorTex(colors[i % colors.length]),
-  front: backPlaceholder,
   back: backPlaceholder,
   elementScale: 1.2 + i * 0.05,
 }));


### PR DESCRIPTION
## Summary
- calculate fan angle for each card in IntroDeck
- wrap IntroDeck return value in React fragment
- correct IntroShuffle usage
- fix duplicate property in SpreadReveal

## Testing
- `npx tsc -p tsconfig.json --noEmit`

------
https://chatgpt.com/codex/tasks/task_e_686d56f8f4888331b23ce771710ecfe4