### PR TITLE
Fix duplicate card property

### DIFF
--- a/src/components/Projects/SpreadReveal.tsx
+++ b/src/components/Projects/SpreadReveal.tsx
@@ -20,7 +20,6 @@ const colorTex = (c: string) =>
 
 const defaultCards = Array.from({ length: 6 }, (_, i) => ({
   front: colorTex(colors[i % colors.length]),
-  front: backPlaceholder,
   back: backPlaceholder,
   elementScale: 1.2 + i * 0.05,
 }));


### PR DESCRIPTION
## Summary
- fix SpreadReveal default card properties

## Testing
- `npm run build` *(fails: esbuild binary mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686d56fb6544833181e56eca926489ec