### PR TITLE
Fix scroll container tracking

### DIFF
--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -26,8 +26,7 @@ const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({
 }) => {
   // Listen to the wrapper’s actual scroll
   const { scrollYProgress } = useScroll({
-    target: scrollContainer,
-    offset: ["start start", "end end"],
+    container: scrollContainer,
   });
 
   // Break the scroll into four scene progresses


### PR DESCRIPTION
## Summary
- track scroll progress using the scroll container

## Testing
- `npm run build` *(fails: platform mismatch for esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_686d591de5ec8331a7659a7de48ccb1b