### PR TITLE
Remove dangling IntroShuffle

### DIFF
--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -8,7 +8,6 @@ import IntroDeck from "./IntroDeck";
 import SpreadReveal from "./SpreadReveal";
 import ProjectDeck from "./ProjectDeck";
 import ProjectCardInfo from "./ProjectCardInfo";
-import IntroShuffle from "./IntroShuffle";
 
 interface ProjectStoryboardProps {
   scrollContainer: React.RefObject<HTMLElement>;
@@ -82,7 +81,6 @@ const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({
         <ProjectCardInfo progress={s3} />
       </group>
     </Canvas>
-    <IntroShuffle progress={s0} />
     </>
   );
 };


### PR DESCRIPTION
## Summary
- clean up `ProjectStoryboard` by deleting the `IntroShuffle` component after the canvas

## Testing
- `npm run build` *(fails: esbuild binary for darwin-arm64)*

------
https://chatgpt.com/codex/tasks/task_e_686d5dd4cc80833184c3938c9837410f