### PR TITLE
Refactor intro deck shuffle

### DIFF
--- a/src/components/Projects/Card3D.tsx
+++ b/src/components/Projects/Card3D.tsx
@@ -1,5 +1,5 @@
 // src/components/Projects/Card3D.tsx
-import React, { useRef } from "react";
+import React, { useRef, forwardRef } from "react";
 import { useFrame, useThree } from "@react-three/fiber";
 import { useTexture } from "@react-three/drei";
 import { MotionValue } from "framer-motion";
@@ -16,6 +16,7 @@ export interface Card3DProps {
   width?:    number;          // world units (optional override)
   height?:   number;          // world units (optional override)
   thickness?: number;
+  borderColor?: string;       // rim colour
   /** 0 → 1 motion value; rotation Y = π * value */
   flip?: MotionValue<number>;
   /** 0 → 1 motion value; 1 = normal scale, >1 = pop-out */
@@ -27,24 +28,25 @@ export interface Card3DProps {
 }
 
 /* ───────────────────────────── Component */
-const Card3D: React.FC<Card3DProps> = ({
+const Card3D = forwardRef<THREE.Group, Card3DProps>(({
   frontSrc,
   backSrc,
   width,
   height,
   thickness = 0.02,
+  borderColor = "#e0e0e0",
   flip,
   pop,
   popScale = 1.15,
   onClick,
   ...rest
-}) => {
+}, ref) => {
   /* responsive default size based on viewport */
   const { viewport } = useThree();
   const base = Math.min(viewport.width, viewport.height);      // scene units
   const w = width ?? base * 0.08;      // 25 % of the shorter side
   const h = height ?? w * 1.4;
-  const group = useRef<THREE.Group>(null);
+  const innerRef = useRef<THREE.Group>(null);
 
   /* textures (lazy) */
   const [frontMap] = useTexture([frontSrc ?? frontPlaceholder]);
@@ -52,7 +54,7 @@ const Card3D: React.FC<Card3DProps> = ({
 
   /* animation on every frame (cheap) */
   useFrame(() => {
-    const g = group.current;
+    const g = (ref as React.MutableRefObject<THREE.Group | null>)?.current ?? innerRef.current;
     if (!g) return;
 
     /* flip */
@@ -67,11 +69,19 @@ const Card3D: React.FC<Card3DProps> = ({
 
   /* ───────────────────────────── Render */
   return (
-    <group ref={group} onClick={onClick} {...rest}>
+    <group
+      ref={(node) => {
+        innerRef.current = node;
+        if (typeof ref === "function") ref(node);
+        else if (ref) (ref as React.MutableRefObject<THREE.Group | null>).current = node;
+      }}
+      onClick={onClick}
+      {...rest}
+    >
       {/* subtle bevel: thin box for the rim */}
       <mesh>
         <boxGeometry args={[w, h, thickness]} />
-        <meshStandardMaterial color="#e0e0e0" metalness={0.25} roughness={0.8} />
+        <meshStandardMaterial color={borderColor} metalness={0.25} roughness={0.8} />
       </mesh>
 
       {/* front plane */}
@@ -88,5 +98,7 @@ const Card3D: React.FC<Card3DProps> = ({
     </group>
   );
 };
+
+Card3D.displayName = "Card3D";
 
 export default Card3D;

--- a/src/components/Projects/IntroDeck.tsx
+++ b/src/components/Projects/IntroDeck.tsx
@@ -1,109 +1,50 @@
-import React, { useMemo, useRef } from "react";
-import { MotionValue, useTransform } from "framer-motion";
-import { useFrame, useThree } from "@react-three/fiber";
+import React from "react";
 import * as THREE from "three";
-import Card3D from "./Card3D";
-import IntroShuffle from "./IntroShuffle";
+import Card3D, { Card3DProps } from "./Card3D";
 
-interface IntroDeckProps {
-  progress: MotionValue<number>;
-  cardCount?: number;
-  radius?: number;
+export interface IntroDeckProps {
+  /** List of card props defining the deck order */
+  cards?: Card3DProps[];
+  /** Optional ref to the deck group */
+  deckRef?: React.Ref<THREE.Group>;
+  /** Refs for each card wrapper for animation */
+  cardRefs?: React.MutableRefObject<THREE.Group[]>;
+  /** Z-spacing between stacked cards */
+  spacing?: number;
 }
 
+const colors = ["red", "blue", "green", "yellow", "purple", "pink"];
+const colorTex = (c: string) =>
+  `data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'><rect width='1' height='1' fill='${encodeURIComponent(
+    c
+  )}'/></svg>`;
+
+const defaultCards: Card3DProps[] = Array.from({ length: 6 }, (_, i) => ({
+  frontSrc: colorTex(colors[i % colors.length]),
+}));
+
 const IntroDeck: React.FC<IntroDeckProps> = ({
-  progress,
-  cardCount = 6,
-  radius,
+  cards = defaultCards,
+  deckRef,
+  cardRefs,
+  spacing = 0.03,
 }) => {
-  const { viewport } = useThree();
-  const fanRadius = radius ?? viewport.width * 0.85; // 45 % of screen width
-  const shuffleProg = useTransform(progress, [0, 0.3], [0, 1], { clamp: true });
-  const rotateProg = useTransform(progress, [0.05, 0.35], [0, 1], { clamp: true });
-  const fanProg = useTransform(progress, [0.35, 0.7], [0, 1], { clamp: true });
-  const flipProg = useTransform(progress, [0.7, 1], [0, 1], { clamp: true });
-
-  const cards = useMemo(() => Array.from({ length: cardCount }, (_, i) => i), [cardCount]);
-  const groupRefs = useRef<THREE.Group[]>([]);
-  const deckRef = useRef<THREE.Group>(null);
-
-  const shuffleOffsets = useMemo(
-    () =>
-      cards.map(() => ({
-        x: (Math.random() - 0.5) * 0.8,
-        y: (Math.random() - 0.5) * 0.2,
-      })),
-    [cards]
-  );
-
-  const shuffleOrder = useMemo(() => {
-    const arr = cards.map((_, i) => i);
-    for (let i = arr.length - 1; i > 0; i--) {
-      const j = Math.floor(Math.random() * (i + 1));
-      [arr[i], arr[j]] = [arr[j], arr[i]];
-    }
-    return arr;
-  }, [cards]);
-
-  const deckSpacing = 0.03;
-
-  useFrame(() => {
-    const dr = deckRef.current;
-    if (dr) {
-      dr.rotation.x = rotateProg.get() * Math.PI * 0.5;
-    }
-
-    const step = 1 / cards.length;
-    const tShuffle = shuffleProg.get();
-    const tFan = fanProg.get();
-    const tFlip = flipProg.get();
-
-    cards.forEach((idx) => {
-      const g = groupRefs.current[idx];
-      if (!g) return;
-
-      const angle = (idx / cards.length) * Math.PI * 2;
-
-      const off = shuffleOffsets[idx];
-      const targetIndex = shuffleOrder[idx];
-
-      const localS = THREE.MathUtils.clamp((tShuffle - step * idx) / step, 0, 1);
-      const out = Math.sin(localS * Math.PI);
-      const baseZ = -idx * deckSpacing;
-      const targetZ = -targetIndex * deckSpacing;
-
-      g.position.x = off.x * out;
-      g.position.y = off.y * out;
-      g.position.z = THREE.MathUtils.lerp(baseZ, targetZ, localS) + out * 0.05;
-      g.rotation.z = angle * tFan;
-
-      g.rotation.y = tFlip * Math.PI;
-
-      const scaleFactor = 1 + (1.15 - 1) * tFan;
-      g.scale.setScalar(scaleFactor);
-    });
-  });
-
-  const colors = ["red", "blue", "green", "yellow", "purple", "pink"];
-  const colorTex = (c: string) =>
-    `data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'><rect width='1' height='1' fill='${encodeURIComponent(
-      c
-    )}'/></svg>`;
+  if (cardRefs && cardRefs.current.length !== cards.length) {
+    cardRefs.current = Array(cards.length).fill(null as unknown as THREE.Group);
+  }
 
   return (
-    <>
-      <IntroShuffle progress={progress} cardCount={cardCount} />
-      <group ref={deckRef}>
-        {cards.map((idx) => (
-          <group key={idx} ref={(el) => (groupRefs.current[idx] = el!)}>
-            <Card3D
-              frontSrc={colorTex(colors[idx % colors.length])}
-              backSrc={undefined}
-            />
-          </group>
-        ))}
-      </group>
-    </>
+    <group ref={deckRef}>
+      {cards.map((card, i) => (
+        <group
+          key={i}
+          ref={cardRefs ? (el) => (cardRefs.current[i] = el!) : undefined}
+          position={[0, 0, -i * spacing]}
+        >
+          <Card3D {...card} />
+        </group>
+      ))}
+    </group>
   );
 };
 

--- a/src/components/Projects/IntroShuffle.tsx
+++ b/src/components/Projects/IntroShuffle.tsx
@@ -1,52 +1,53 @@
-
 import React, { useMemo, useRef } from "react";
 import { MotionValue, useTransform } from "framer-motion";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
-import Card3D from "./Card3D";
+import IntroDeck from "./IntroDeck";
+import { Card3DProps } from "./Card3D";
 
-interface IntroShuffleProps {
+export interface IntroShuffleProps {
   progress: MotionValue<number>;
-  cardCount?: number;
+  /** Optional custom cards */
+  cards?: Card3DProps[];
 }
 
 /**
- * Basic 3D card shuffle animation. Each card is pulled out of the deck and
- * returned at a different position while the whole deck tilts forward.
- *
- * This component is intentionally simple and keeps the shuffle logic separate
- * from the rest of the intro animations.
+ * Animates the IntroDeck with a shuffle, fan and flip sequence.
  */
 const IntroShuffle: React.FC<IntroShuffleProps> = ({
   progress,
-  cardCount = 6,
+  cards,
 }) => {
-  const cards = useMemo(() => Array.from({ length: cardCount }, (_, i) => i), [
-    cardCount,
-  ]);
-  const groupRefs = useRef<THREE.Group[]>([]);
+
   const deckRef = useRef<THREE.Group>(null);
+  const cardRefs = useRef<THREE.Group[]>([]);
+
+  const cardCount = cards?.length ?? 6;
+  const indices = useMemo(() => Array.from({ length: cardCount }, (_, i) => i), [cardCount]);
 
   const shuffleOffsets = useMemo(
     () =>
-      cards.map(() => ({
+      indices.map(() => ({
         x: (Math.random() - 0.5) * 0.8,
         y: (Math.random() - 0.5) * 0.2,
       })),
-    [cards]
+    [indices]
   );
 
   const shuffleOrder = useMemo(() => {
-    const arr = cards.map((_, i) => i);
+    const arr = indices.map((_, i) => i);
     for (let i = arr.length - 1; i > 0; i--) {
       const j = Math.floor(Math.random() * (i + 1));
       [arr[i], arr[j]] = [arr[j], arr[i]];
     }
     return arr;
-  }, [cards]);
+  }, [indices]);
 
-  const rotateProg = useTransform(progress, [0, 1], [0, 1]);
+  const shuffleProg = useTransform(progress, [0, 0.3], [0, 1], { clamp: true });
+  const rotateProg = useTransform(progress, [0.05, 0.35], [0, 1], { clamp: true });
+  const fanProg = useTransform(progress, [0.35, 0.7], [0, 1], { clamp: true });
+  const flipProg = useTransform(progress, [0.7, 1], [0, 1], { clamp: true });
 
   const deckSpacing = 0.03;
 
@@ -54,44 +55,36 @@ const IntroShuffle: React.FC<IntroShuffleProps> = ({
     const dr = deckRef.current;
     if (dr) dr.rotation.x = rotateProg.get() * Math.PI * 0.5;
 
-    const t = progress.get();
-    const step = 1 / cards.length;
+    const step = 1 / cardCount;
+    const tShuffle = shuffleProg.get();
+    const tFan = fanProg.get();
+    const tFlip = flipProg.get();
 
-    cards.forEach((idx) => {
-      const g = groupRefs.current[idx];
+    indices.forEach((idx) => {
+      const g = cardRefs.current[idx];
       if (!g) return;
 
+      const angle = (idx / cardCount) * Math.PI * 2;
       const off = shuffleOffsets[idx];
       const targetIndex = shuffleOrder[idx];
 
-      const local = THREE.MathUtils.clamp((t - step * idx) / step, 0, 1);
-      const out = Math.sin(local * Math.PI);
+      const localS = THREE.MathUtils.clamp((tShuffle - step * idx) / step, 0, 1);
+      const out = Math.sin(localS * Math.PI);
       const baseZ = -idx * deckSpacing;
       const targetZ = -targetIndex * deckSpacing;
 
       g.position.x = off.x * out;
       g.position.y = off.y * out;
-      g.position.z = THREE.MathUtils.lerp(baseZ, targetZ, local) + out * 0.05;
+      g.position.z = THREE.MathUtils.lerp(baseZ, targetZ, localS) + out * 0.05;
+      g.rotation.z = angle * tFan;
+      g.rotation.y = tFlip * Math.PI;
+
+      const scaleFactor = 1 + (1.15 - 1) * tFan;
+      g.scale.setScalar(scaleFactor);
     });
   });
 
-  /* simple colour variety for front textures */
-  const colors = ["red", "blue", "green", "yellow", "purple", "pink"];
-  const colorTex = (c: string) =>
-    `data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'><rect width='1' height='1' fill='${encodeURIComponent(
-      c
-    )}'/></svg>`;
-
-  return (
-    <group ref={deckRef}>
-      {cards.map((idx) => (
-        <group key={idx} ref={(el) => (groupRefs.current[idx] = el!)}>
-          <Card3D frontSrc={colorTex(colors[idx % colors.length])} />
-        </group>
-      ))}
-    </group>
-
-  );
+  return <IntroDeck cards={cards} deckRef={deckRef} cardRefs={cardRefs} spacing={0.03} />;
 };
 
 export default IntroShuffle;

--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -4,7 +4,7 @@ import { Canvas } from "@react-three/fiber";
 import { AdaptiveDpr, PerspectiveCamera, Environment } from "@react-three/drei";
 import { useScroll, useTransform, MotionValue } from "framer-motion";
 
-import IntroDeck from "./IntroDeck";
+import IntroShuffle from "./IntroShuffle";
 import SpreadReveal from "./SpreadReveal";
 import ProjectDeck from "./ProjectDeck";
 import ProjectCardInfo from "./ProjectCardInfo";
@@ -75,7 +75,7 @@ const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({
 
       {/* No manual Y-offset; group is centered at [0,0,0] */}
       <group scale={1.4}>
-        <IntroDeck progress={s0} cardCount={6} />
+        <IntroShuffle progress={s0} />
         <SpreadReveal progress={s1} cards={undefined} />
         <ProjectDeck progress={s2} />
         <ProjectCardInfo progress={s3} />


### PR DESCRIPTION
## Summary
- simplify `Card3D` component and expose rim colour and forwardRef
- rebuild `IntroDeck` as a simple ordered stack of cards
- update `IntroShuffle` to animate an `IntroDeck`
- call `IntroShuffle` from `ProjectStoryboard`

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686d607d718083318c0ad3fda8ffcc18