### PR TITLE
Fix hydration issue in ProjectStoryboard

### DIFF
--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -26,6 +26,7 @@ const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({
   // Listen to the wrapper’s actual scroll
   const { scrollYProgress } = useScroll({
     container: scrollContainer,
+    layoutEffect: false,
   });
 
   // Break the scroll into four scene progresses


### PR DESCRIPTION
## Summary
- disable layout effect in `useScroll` to prevent hydration mismatch

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686d6cb371288331a0f666dc86d94fc8