### PR TITLE
Fix full flip rotation

### DIFF
--- a/src/components/Projects/IntroShuffle.tsx
+++ b/src/components/Projects/IntroShuffle.tsx
@@ -77,7 +77,7 @@ const IntroShuffle: React.FC<IntroShuffleProps> = ({
       g.position.y = off.y * out;
       g.position.z = THREE.MathUtils.lerp(baseZ, targetZ, localS) + out * 0.05;
       g.rotation.z = angle * tFan;
-      g.rotation.y = tFlip * Math.PI;
+      g.rotation.y = tFlip * Math.PI * 2;
 
       const scaleFactor = 1 + (1.15 - 1) * tFan;
       g.scale.setScalar(scaleFactor);


### PR DESCRIPTION
## Summary
- rotate IntroShuffle cards a full turn when flipping

## Testing
- `git status --short`

------
https://chatgpt.com/codex/tasks/task_e_686d6cb9e71c8331baa1534cd04f045f