### PR TITLE
Fix THREE color management

### DIFF
--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -1,6 +1,7 @@
 // src/components/Projects/ProjectStoryboard.tsx
 import React, { Suspense, useEffect } from "react";
 import { Canvas } from "@react-three/fiber";
+import * as THREE from "three";
 import { AdaptiveDpr, PerspectiveCamera, Environment } from "@react-three/drei";
 import { useScroll, useTransform, MotionValue } from "framer-motion";
 
@@ -60,7 +61,15 @@ const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({
 
   return (
     <>
-    <Canvas className="fixed inset-0 z-10 pointer-events-none" shadows>
+    <Canvas
+      className="fixed inset-0 z-10 pointer-events-none"
+      shadows
+      gl={{ preserveDrawingBuffer: false }}
+      onCreated={({ gl }) => {
+        gl.colorSpace = THREE.SRGBColorSpace;
+        THREE.ColorManagement.enabled = true;
+      }}
+    >
       {/* Full-viewport Canvas */}
       <AdaptiveDpr pixelated />
       <PerspectiveCamera makeDefault position={[0, 0, 6]} fov={45} />


### PR DESCRIPTION
## Summary
- configure the Canvas renderer to use sRGB color space

## Testing
- `npm run build` *(fails: esbuild binary mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686d6cc4dd308331b4f94e7bba2b28fd