### PR TITLE
Update IntroShuffle card flips

### DIFF
--- a/src/components/Projects/IntroDeck.tsx
+++ b/src/components/Projects/IntroDeck.tsx
@@ -1,6 +1,7 @@
 import React from "react";
 import * as THREE from "three";
 import Card3D, { Card3DProps } from "./Card3D";
+import { MotionValue } from "framer-motion";
 
 export interface IntroDeckProps {
   /** List of card props defining the deck order */
@@ -9,6 +10,8 @@ export interface IntroDeckProps {
   deckRef?: React.Ref<THREE.Group>;
   /** Refs for each card wrapper for animation */
   cardRefs?: React.MutableRefObject<THREE.Group[]>;
+  /** Flip values per card */
+  flipVals?: MotionValue<number>[];
   /** Z-spacing between stacked cards */
   spacing?: number;
 }
@@ -27,6 +30,7 @@ const IntroDeck: React.FC<IntroDeckProps> = ({
   cards = defaultCards,
   deckRef,
   cardRefs,
+  flipVals,
   spacing = 0.03,
 }) => {
   if (cardRefs && cardRefs.current.length !== cards.length) {
@@ -41,7 +45,7 @@ const IntroDeck: React.FC<IntroDeckProps> = ({
           ref={cardRefs ? (el) => (cardRefs.current[i] = el!) : undefined}
           position={[0, 0, -i * spacing]}
         >
-          <Card3D {...card} />
+          <Card3D {...card} flip={flipVals ? flipVals[i] : undefined} />
         </group>
       ))}
     </group>

--- a/src/components/Projects/IntroShuffle.tsx
+++ b/src/components/Projects/IntroShuffle.tsx
@@ -1,5 +1,5 @@
 import React, { useMemo, useRef } from "react";
-import { MotionValue, useTransform } from "framer-motion";
+import { MotionValue, useTransform, motionValue } from "framer-motion";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
@@ -22,9 +22,14 @@ const IntroShuffle: React.FC<IntroShuffleProps> = ({
 
   const deckRef = useRef<THREE.Group>(null);
   const cardRefs = useRef<THREE.Group[]>([]);
+  const flipVals = useRef<MotionValue<number>[]>([]);
 
   const cardCount = cards?.length ?? 6;
   const indices = useMemo(() => Array.from({ length: cardCount }, (_, i) => i), [cardCount]);
+
+  if (flipVals.current.length !== cardCount) {
+    flipVals.current = indices.map(() => motionValue(0));
+  }
 
   const shuffleOffsets = useMemo(
     () =>
@@ -77,14 +82,23 @@ const IntroShuffle: React.FC<IntroShuffleProps> = ({
       g.position.y = off.y * out;
       g.position.z = THREE.MathUtils.lerp(baseZ, targetZ, localS) + out * 0.05;
       g.rotation.z = angle * tFan;
-      g.rotation.y = tFlip * Math.PI;
+      g.rotation.y = 0;
+      flipVals.current[idx].set(tFlip);
 
       const scaleFactor = 1 + (1.15 - 1) * tFan;
       g.scale.setScalar(scaleFactor);
     });
   });
 
-  return <IntroDeck cards={cards} deckRef={deckRef} cardRefs={cardRefs} spacing={0.03} />;
+  return (
+    <IntroDeck
+      cards={cards}
+      deckRef={deckRef}
+      cardRefs={cardRefs}
+      spacing={0.03}
+      flipVals={flipVals.current}
+    />
+  );
 };
 
 export default IntroShuffle;


### PR DESCRIPTION
## Summary
- initialize per-card flip motion values
- set individual flip values each frame
- forward flip motion values through IntroDeck

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build` *(fails: platform mismatch for esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_686d6cd222c083318552d4b4855ca941