### PR TITLE
Implement storyboard sections

### DIFF
--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -1,10 +1,5 @@
-// src/components/Projects/ProjectStoryboard.tsx
-import React, { Suspense, useEffect } from "react";
-import { Canvas } from "@react-three/fiber";
-import * as THREE from "three";
-import { AdaptiveDpr, PerspectiveCamera, Environment } from "@react-three/drei";
-import { useScroll, useTransform, MotionValue } from "framer-motion";
-
+import React from "react";
+import StoryboardSection from "./StoryboardSection";
 import IntroShuffle from "./IntroShuffle";
 import SpreadReveal from "./SpreadReveal";
 import ProjectDeck from "./ProjectDeck";
@@ -12,85 +7,23 @@ import ProjectCardInfo from "./ProjectCardInfo";
 
 interface ProjectStoryboardProps {
   scrollContainer: React.RefObject<HTMLElement>;
-  sectionBreaks?: [number, number, number, number];
-  autoScrollDelay?: number;
 }
 
-const slice = (mv: MotionValue<number>, range: [number, number]) =>
-  useTransform(mv, range, [0, 1], { clamp: true });
-
-const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({
-  scrollContainer,
-  sectionBreaks = [0.3, 0.6, 0.85, 1.0],
-  autoScrollDelay = 500,
-}) => {
-  // Listen to the wrapper’s actual scroll
-  const { scrollYProgress } = useScroll({
-    container: scrollContainer,
-    layoutEffect: false,
-  });
-
-  // Break the scroll into four scene progresses
-  const s0 = slice(scrollYProgress, [0, sectionBreaks[0]]);
-  const s1 = slice(scrollYProgress, [sectionBreaks[0], sectionBreaks[1]]);
-  const s2 = slice(scrollYProgress, [sectionBreaks[1], sectionBreaks[2]]);
-  const s3 = slice(scrollYProgress, [sectionBreaks[2], sectionBreaks[3]]);
-
-  // Optional intro auto-scroll
-  useEffect(() => {
-    const el = scrollContainer.current;
-    if (!el) return;
-    const total = el.scrollHeight - el.clientHeight;
-    if (total < 1) return;
-
-    const start = el.scrollTop;
-    const goal = total * sectionBreaks[0];
-    const dur = 2000;
-    const ease = (t: number) =>
-      t < 0.5 ? 4 * t ** 3 : 1 - Math.pow(-2 * t + 2, 3) / 2;
-    const t0 = performance.now();
-
-    const step = (now: number) => {
-      const u = Math.min((now - t0) / dur, 1);
-      el.scrollTop = start + (goal - start) * ease(u);
-      if (u < 1) requestAnimationFrame(step);
-    };
-
-    const id = window.setTimeout(() => requestAnimationFrame(step), autoScrollDelay);
-    return () => window.clearTimeout(id);
-  }, [scrollContainer, sectionBreaks, autoScrollDelay]);
-
+const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({ scrollContainer }) => {
   return (
     <>
-    <Canvas
-      className="fixed inset-0 z-10 pointer-events-none"
-      shadows
-      gl={{ preserveDrawingBuffer: false }}
-      onCreated={({ gl }) => {
-        gl.colorSpace = THREE.SRGBColorSpace;
-        THREE.ColorManagement.enabled = true;
-      }}
-    >
-      {/* Full-viewport Canvas */}
-      <AdaptiveDpr pixelated />
-      <PerspectiveCamera makeDefault position={[0, 0, 6]} fov={45} />
-
-      {/* Lighting & HDRI */}
-      <ambientLight intensity={0.4} />
-      <directionalLight position={[1, 2, 3]} intensity={1} castShadow />
-      <directionalLight position={[-3, -1, -2]} intensity={0.45} />
-      <Suspense fallback={null}>
-        <Environment preset="sunset" />
-      </Suspense>
-
-      {/* No manual Y-offset; group is centered at [0,0,0] */}
-      <group scale={1.4}>
-        <IntroShuffle progress={s0} />
-        <SpreadReveal progress={s1} cards={undefined} />
-        <ProjectDeck progress={s2} />
-        <ProjectCardInfo progress={s3} />
-      </group>
-    </Canvas>
+      <StoryboardSection container={scrollContainer}>
+        {(p) => <IntroShuffle progress={p} />}
+      </StoryboardSection>
+      <StoryboardSection container={scrollContainer}>
+        {(p) => <SpreadReveal progress={p} />}
+      </StoryboardSection>
+      <StoryboardSection container={scrollContainer}>
+        {(p) => <ProjectDeck progress={p} />}
+      </StoryboardSection>
+      <StoryboardSection container={scrollContainer}>
+        {(p) => <ProjectCardInfo progress={p} />}
+      </StoryboardSection>
     </>
   );
 };

--- a/src/components/Projects/StoryboardSection.tsx
+++ b/src/components/Projects/StoryboardSection.tsx
@@ -1,0 +1,49 @@
+import React, { Suspense, useRef } from "react";
+import { Canvas } from "@react-three/fiber";
+import { AdaptiveDpr, PerspectiveCamera, Environment } from "@react-three/drei";
+import { MotionValue, useScroll } from "framer-motion";
+import * as THREE from "three";
+
+interface StoryboardSectionProps {
+  container: React.RefObject<HTMLElement>;
+  children: (progress: MotionValue<number>) => React.ReactNode;
+}
+
+const StoryboardSection: React.FC<StoryboardSectionProps> = ({
+  container,
+  children,
+}) => {
+  const ref = useRef<HTMLElement>(null);
+  const { scrollYProgress } = useScroll({
+    container,
+    target: ref,
+    offset: ["start end", "end start"],
+    layoutEffect: false,
+  });
+
+  return (
+    <section ref={ref} className="h-screen sticky top-0">
+      <Canvas
+        className="w-full h-full pointer-events-none"
+        shadows
+        gl={{ preserveDrawingBuffer: false }}
+        onCreated={({ gl }) => {
+          gl.colorSpace = THREE.SRGBColorSpace;
+          THREE.ColorManagement.enabled = true;
+        }}
+      >
+        <AdaptiveDpr pixelated />
+        <PerspectiveCamera makeDefault position={[0, 0, 6]} fov={45} />
+        <ambientLight intensity={0.4} />
+        <directionalLight position={[1, 2, 3]} intensity={1} castShadow />
+        <directionalLight position={[-3, -1, -2]} intensity={0.45} />
+        <Suspense fallback={null}>
+          <Environment preset="sunset" />
+        </Suspense>
+        <group scale={1.4}>{children(scrollYProgress)}</group>
+      </Canvas>
+    </section>
+  );
+};
+
+export default StoryboardSection;

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -4,7 +4,6 @@ import ProjectStoryboard from "../components/Projects/ProjectStoryboard";
 import Footer from "../components/Footer";
 
 const ProjectsPage: React.FC = () => {
-  // This div is now the real, full-screen scroll container
   const scrollRef = useRef<HTMLDivElement>(null);
 
   return (
@@ -12,12 +11,7 @@ const ProjectsPage: React.FC = () => {
       ref={scrollRef}
       className="relative w-screen h-screen bg-white overflow-y-auto overflow-x-hidden"
     >
-      {/* Fixed Canvas reads from this scroll container */}
       <ProjectStoryboard scrollContainer={scrollRef} />
-
-      {/* 4 scenes → 4× viewport scroll */}
-      <div style={{ height: "400vh" }} />
-
       <Footer />
     </div>
   );


### PR DESCRIPTION
## Summary
- add `StoryboardSection` wrapper that pins each canvas
- refactor `ProjectStoryboard` to use section wrappers
- simplify `ProjectsPage` markup

## Testing
- `npm run dev` *(fails: platform mismatch for esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_686d6dbd7ea48331bbe1727da038fd7e