### PR TITLE
Adjust storyboard section for scroll progress

### DIFF
--- a/src/components/Projects/StoryboardSection.tsx
+++ b/src/components/Projects/StoryboardSection.tsx
@@ -17,31 +17,33 @@ const StoryboardSection: React.FC<StoryboardSectionProps> = ({
   const { scrollYProgress } = useScroll({
     container,
     target: ref,
-    offset: ["start end", "end start"],
+    offset: ["start start", "end start"],
     layoutEffect: false,
   });
 
   return (
-    <section ref={ref} className="h-screen sticky top-0">
-      <Canvas
-        className="w-full h-full pointer-events-none"
-        shadows
-        gl={{ preserveDrawingBuffer: false }}
-        onCreated={({ gl }) => {
-          gl.colorSpace = THREE.SRGBColorSpace;
-          THREE.ColorManagement.enabled = true;
-        }}
-      >
-        <AdaptiveDpr pixelated />
-        <PerspectiveCamera makeDefault position={[0, 0, 6]} fov={45} />
-        <ambientLight intensity={0.4} />
-        <directionalLight position={[1, 2, 3]} intensity={1} castShadow />
-        <directionalLight position={[-3, -1, -2]} intensity={0.45} />
-        <Suspense fallback={null}>
-          <Environment preset="sunset" />
-        </Suspense>
-        <group scale={1.4}>{children(scrollYProgress)}</group>
-      </Canvas>
+    <section ref={ref} className="h-[200vh]">
+      <div className="sticky top-0 h-screen">
+        <Canvas
+          className="w-full h-full pointer-events-none"
+          shadows
+          gl={{ preserveDrawingBuffer: false }}
+          onCreated={({ gl }) => {
+            gl.colorSpace = THREE.SRGBColorSpace;
+            THREE.ColorManagement.enabled = true;
+          }}
+        >
+          <AdaptiveDpr pixelated />
+          <PerspectiveCamera makeDefault position={[0, 0, 6]} fov={45} />
+          <ambientLight intensity={0.4} />
+          <directionalLight position={[1, 2, 3]} intensity={1} castShadow />
+          <directionalLight position={[-3, -1, -2]} intensity={0.45} />
+          <Suspense fallback={null}>
+            <Environment preset="sunset" />
+          </Suspense>
+          <group scale={1.4}>{children(scrollYProgress)}</group>
+        </Canvas>
+      </div>
     </section>
   );
 };


### PR DESCRIPTION
## Summary
- use outer section for scroll tracking with `start start` offset
- make the canvas sticky inside a taller section to provide scroll distance

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686eac63ab1c83319fc5870c318781e1