### PR TITLE
Fix ProjectsPage height to grow with content

### DIFF
--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -13,7 +13,7 @@ const ProjectsPage: React.FC = () => {
   return (
     <div
       ref={scrollRef}
-      className="relative w-screen h-screen bg-white overflow-y-auto overflow-x-hidden"
+      className="relative w-screen min-h-screen bg-white overflow-y-auto overflow-x-hidden"
     >
 
       <ProjectStoryboard scrollContainer={scrollRef} />


### PR DESCRIPTION
## Summary
- allow ProjectsPage to extend beyond a single viewport by replacing `h-screen` with `min-h-screen`

## Testing
- `npm run build` *(fails: installed esbuild for darwin, but linux-x64 needed)*
- `npm run dev` *(fails: installed esbuild for darwin, but linux-x64 needed)*

------
https://chatgpt.com/codex/tasks/task_e_686eadb8d0c88331b26ba387e6075840