### PR TITLE
Remove duplicate displayName

### DIFF
--- a/src/components/Projects/Card3D.tsx
+++ b/src/components/Projects/Card3D.tsx
@@ -105,6 +105,4 @@ const Card3D = forwardRef<THREE.Group, Card3DProps>(({
 
 Card3D.displayName = "Card3D";
 
-Card3D.displayName = "Card3D";
-
 export default Card3D;


### PR DESCRIPTION
## Summary
- remove duplicate `displayName` assignment in `Card3D`

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686eb4a9eab08331bb3b21c38f2bd077