### PR TITLE
Refactor storyboard scroll handling

### DIFF
--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -1,4 +1,5 @@
 import React, { RefObject } from "react";
+import { MotionValue, useScroll, useTransform, useMotionValueEvent } from "framer-motion";
 import StoryboardSection from "./StoryboardSection";
 
 import IntroShuffle from "./IntroShuffle";
@@ -17,26 +18,53 @@ export interface ProjectStoryboardProps {
 /* ──────────────────────────────────────────────────────────────
    Component
    ────────────────────────────────────────────────────────────── */
-const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({
-  scrollContainer,
-}) => (
-  <>
-    <StoryboardSection container={scrollContainer}>
-      {(p) => <IntroShuffle progress={p} />}
-    </StoryboardSection>
+const slice = (
+  mv: MotionValue<number>,
+  start: number,
+  end: number
+) => useTransform(mv, [start, end], [0, 1]);
 
-    <StoryboardSection container={scrollContainer}>
-      {(p) => <SpreadReveal progress={p} />}
-    </StoryboardSection>
+const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({ scrollContainer }) => {
+  // Track the scroll progress of the entire storyboard container
+  const { scrollYProgress } = useScroll({ container: scrollContainer, layoutEffect: false });
 
-    <StoryboardSection container={scrollContainer}>
-      {(p) => <ProjectDeck progress={p} />}
-    </StoryboardSection>
+  // Break global progress into equal segments for each scene
+  const s0 = slice(scrollYProgress, 0.0, 0.25);
+  const s1 = slice(scrollYProgress, 0.25, 0.5);
+  const s2 = slice(scrollYProgress, 0.5, 0.75);
+  const s3 = slice(scrollYProgress, 0.75, 1.0);
+  const segments = [s0, s1, s2, s3];
 
-    <StoryboardSection container={scrollContainer}>
-      {(p) => <ProjectCardInfo progress={p} />}
-    </StoryboardSection>
-  </>
-);
+  // Optionally prevent scrolling into the next segment until the current one completes
+  useMotionValueEvent(scrollYProgress, "change", (v) => {
+    const el = scrollContainer.current;
+    if (!el) return;
+    const total = el.scrollHeight - el.clientHeight;
+    for (let i = 0; i < segments.length; i++) {
+      const start = i * 0.25;
+      const end = (i + 1) * 0.25;
+      const local = segments[i].get();
+      if (v > end && local < 1) {
+        el.scrollTop = end * total;
+        return;
+      } else if (v < start && local > 0) {
+        el.scrollTop = start * total;
+        return;
+      }
+    }
+  });
+
+  return (
+    <>
+      <StoryboardSection progress={s0}>{(p) => <IntroShuffle progress={p} />}</StoryboardSection>
+
+      <StoryboardSection progress={s1}>{(p) => <SpreadReveal progress={p} />}</StoryboardSection>
+
+      <StoryboardSection progress={s2}>{(p) => <ProjectDeck progress={p} />}</StoryboardSection>
+
+      <StoryboardSection progress={s3}>{(p) => <ProjectCardInfo progress={p} />}</StoryboardSection>
+    </>
+  );
+};
 
 export default ProjectStoryboard;

--- a/src/components/Projects/StoryboardSection.tsx
+++ b/src/components/Projects/StoryboardSection.tsx
@@ -1,28 +1,21 @@
-import React, { Suspense, useRef } from "react";
+import React, { Suspense } from "react";
 import { Canvas } from "@react-three/fiber";
 import { AdaptiveDpr, PerspectiveCamera, Environment } from "@react-three/drei";
-import { MotionValue, useScroll } from "framer-motion";
+import { MotionValue } from "framer-motion";
 import * as THREE from "three";
 
 interface StoryboardSectionProps {
-  container: React.RefObject<HTMLElement>;
+  /** Scene progress provided by ProjectStoryboard */
+  progress: MotionValue<number>;
   children: (progress: MotionValue<number>) => React.ReactNode;
 }
 
 const StoryboardSection: React.FC<StoryboardSectionProps> = ({
-  container,
+  progress,
   children,
 }) => {
-  const ref = useRef<HTMLElement>(null);
-  const { scrollYProgress } = useScroll({
-    container,
-    target: ref,
-    offset: ["start start", "end start"],
-    layoutEffect: false,
-  });
-
   return (
-    <section ref={ref} className="h-[200vh]">
+    <section className="h-screen">
       {/*
         Sticky wrapper stays fixed while this section's scroll progress
         is between 0 and 1. Once scrollYProgress reaches 1, the wrapper
@@ -35,7 +28,7 @@ const StoryboardSection: React.FC<StoryboardSectionProps> = ({
           shadows
           gl={{ preserveDrawingBuffer: false }}
           onCreated={({ gl }) => {
-            gl.colorSpace = THREE.SRGBColorSpace;
+            (gl as any).colorSpace = THREE.SRGBColorSpace;
             THREE.ColorManagement.enabled = true;
           }}
         >
@@ -47,7 +40,7 @@ const StoryboardSection: React.FC<StoryboardSectionProps> = ({
           <Suspense fallback={null}>
             <Environment preset="sunset" />
           </Suspense>
-          <group scale={1.4}>{children(scrollYProgress)}</group>
+          <group scale={1.4}>{children(progress)}</group>
         </Canvas>
       </div>
     </section>

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -5,21 +5,19 @@ import Footer from "../components/Footer";
 
 const ProjectsPage: React.FC = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const sec0 = useRef<HTMLElement>(null);
-  const sec1 = useRef<HTMLElement>(null);
-  const sec2 = useRef<HTMLElement>(null);
-  const sec3 = useRef<HTMLElement>(null);
 
   return (
-    <div
-      ref={scrollRef}
-      className="relative w-screen min-h-screen bg-white overflow-y-auto overflow-x-hidden"
-    >
-
-      <ProjectStoryboard scrollContainer={scrollRef} />
+    <>
+      <div
+        ref={scrollRef}
+        className="relative w-screen overflow-y-auto overflow-x-hidden bg-white"
+        style={{ height: "400vh" }}
+      >
+        <ProjectStoryboard scrollContainer={scrollRef} />
+      </div>
 
       <Footer />
-    </div>
+    </>
   );
 };
 


### PR DESCRIPTION
## Summary
- manage storyboard progress with a single `useScroll` in `ProjectStoryboard`
- pass scene progress slices down into `StoryboardSection`
- pin each canvas without tracking its own progress
- size the project scroll container to 4× viewport height
- guard against overscrolling between scenes

## Testing
- `./node_modules/.bin/tsc --noEmit`


------
https://chatgpt.com/codex/tasks/task_e_686eb4ab090c8331b82f0bd8436c5de2