### PR TITLE
Make scroll container height dynamic

### DIFF
--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -7,6 +7,8 @@ import SpreadReveal from "./SpreadReveal";
 import ProjectDeck from "./ProjectDeck";
 import ProjectCardInfo from "./ProjectCardInfo";
 
+export const sceneCount = 4;
+
 /* ──────────────────────────────────────────────────────────────
    Props
    ────────────────────────────────────────────────────────────── */
@@ -29,11 +31,10 @@ const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({ scrollContainer }
   const { scrollYProgress } = useScroll({ container: scrollContainer, layoutEffect: false });
 
   // Break global progress into equal segments for each scene
-  const s0 = slice(scrollYProgress, 0.0, 0.25);
-  const s1 = slice(scrollYProgress, 0.25, 0.5);
-  const s2 = slice(scrollYProgress, 0.5, 0.75);
-  const s3 = slice(scrollYProgress, 0.75, 1.0);
-  const segments = [s0, s1, s2, s3];
+  const segments = Array.from({ length: sceneCount }, (_, i) =>
+    slice(scrollYProgress, i / sceneCount, (i + 1) / sceneCount)
+  );
+  const [s0, s1, s2, s3] = segments;
 
   // Optionally prevent scrolling into the next segment until the current one completes
   useMotionValueEvent(scrollYProgress, "change", (v) => {
@@ -41,8 +42,8 @@ const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({ scrollContainer }
     if (!el) return;
     const total = el.scrollHeight - el.clientHeight;
     for (let i = 0; i < segments.length; i++) {
-      const start = i * 0.25;
-      const end = (i + 1) * 0.25;
+      const start = i / sceneCount;
+      const end = (i + 1) / sceneCount;
       const local = segments[i].get();
       if (v > end && local < 1) {
         el.scrollTop = end * total;

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,17 +1,18 @@
 // src/pages/ProjectsPage.tsx
 import React, { useRef } from "react";
-import ProjectStoryboard from "../components/Projects/ProjectStoryboard";
+import ProjectStoryboard, { sceneCount } from "../components/Projects/ProjectStoryboard";
 import Footer from "../components/Footer";
 
 const ProjectsPage: React.FC = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
+  const containerHeight = `${sceneCount * 100}vh`;
 
   return (
     <>
       <div
         ref={scrollRef}
         className="relative w-screen overflow-y-auto overflow-x-hidden bg-white"
-        style={{ height: "400vh" }}
+        style={{ height: containerHeight }}
       >
         <ProjectStoryboard scrollContainer={scrollRef} />
       </div>


### PR DESCRIPTION
## Summary
- export a `sceneCount` constant from `ProjectStoryboard`
- compute scene segments using `sceneCount`
- derive the scroll container height from `sceneCount` in `ProjectsPage`

## Testing
- `npm run dev` *(fails: platform-specific esbuild binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_686eb923125083318e9650b891f47bd8