### PR TITLE
Refactor intro scenes for shared deck

### DIFF
--- a/src/components/Projects/IntroShuffle.tsx
+++ b/src/components/Projects/IntroShuffle.tsx
@@ -1,15 +1,17 @@
 import React, { useMemo, useRef } from "react";
-import { MotionValue, useTransform, motionValue } from "framer-motion";
+import { MotionValue, useTransform } from "framer-motion";
 import { useFrame } from "@react-three/fiber";
 import * as THREE from "three";
 
-import IntroDeck from "./IntroDeck";
 import { Card3DProps } from "./Card3D";
 
 export interface IntroShuffleProps {
   progress: MotionValue<number>;
   /** Optional custom cards */
   cards?: Card3DProps[];
+  deckRef: React.RefObject<THREE.Group>;
+  cardRefs: React.MutableRefObject<THREE.Group[]>;
+  flipVals: MotionValue<number>[];
 }
 
 /**
@@ -18,18 +20,12 @@ export interface IntroShuffleProps {
 const IntroShuffle: React.FC<IntroShuffleProps> = ({
   progress,
   cards,
+  deckRef,
+  cardRefs,
+  flipVals,
 }) => {
-
-  const deckRef = useRef<THREE.Group>(null);
-  const cardRefs = useRef<THREE.Group[]>([]);
-  const flipVals = useRef<MotionValue<number>[]>([]);
-
-  const cardCount = cards?.length ?? 6;
+  const cardCount = cards?.length ?? (cardRefs.current.length || 6);
   const indices = useMemo(() => Array.from({ length: cardCount }, (_, i) => i), [cardCount]);
-
-  if (flipVals.current.length !== cardCount) {
-    flipVals.current = indices.map(() => motionValue(0));
-  }
 
   const shuffleOffsets = useMemo(
     () =>
@@ -83,7 +79,7 @@ const IntroShuffle: React.FC<IntroShuffleProps> = ({
       g.position.z = THREE.MathUtils.lerp(baseZ, targetZ, localS) + out * 0.05;
       g.rotation.z = angle * tFan;
 
-      flipVals.current[idx].set(tFlip);
+      flipVals[idx]?.set(tFlip);
       g.rotation.y = tFlip * Math.PI * 2;
 
       const scaleFactor = 1 + (1.15 - 1) * tFan;
@@ -91,15 +87,7 @@ const IntroShuffle: React.FC<IntroShuffleProps> = ({
     });
   });
 
-  return (
-    <IntroDeck
-      cards={cards}
-      deckRef={deckRef}
-      cardRefs={cardRefs}
-      spacing={0.03}
-      flipVals={flipVals.current}
-    />
-  );
+  return null;
 };
 
 export default IntroShuffle;

--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -1,13 +1,51 @@
-import React, { RefObject } from "react";
-import { MotionValue, useScroll, useTransform, useMotionValueEvent } from "framer-motion";
+import React, { RefObject, useRef } from "react";
+import { MotionValue, useScroll, useTransform, useMotionValueEvent, motionValue } from "framer-motion";
 import StoryboardSection from "./StoryboardSection";
 
+import IntroDeck from "./IntroDeck";
 import IntroShuffle from "./IntroShuffle";
 import SpreadReveal from "./SpreadReveal";
 import ProjectDeck from "./ProjectDeck";
 import ProjectCardInfo from "./ProjectCardInfo";
+import * as THREE from "three";
 
 export const sceneCount = 4;
+
+interface IntroSequenceProps {
+  shuffleProgress: MotionValue<number>;
+  revealProgress: MotionValue<number>;
+}
+
+const IntroSequence: React.FC<IntroSequenceProps> = ({
+  shuffleProgress,
+  revealProgress,
+}) => {
+  const deckRef = useRef<THREE.Group>(null);
+  const cardRefs = useRef<THREE.Group[]>([]);
+  const flipVals = useRef<MotionValue<number>[]>([]);
+
+  const cardCount = 6;
+  if (flipVals.current.length !== cardCount) {
+    flipVals.current = Array.from({ length: cardCount }, () => motionValue(0));
+  }
+
+  return (
+    <>
+      <IntroDeck deckRef={deckRef} cardRefs={cardRefs} flipVals={flipVals.current} />
+      <IntroShuffle
+        progress={shuffleProgress}
+        deckRef={deckRef}
+        cardRefs={cardRefs}
+        flipVals={flipVals.current}
+      />
+      <SpreadReveal
+        progress={revealProgress}
+        cardRefs={cardRefs}
+        flipVals={flipVals.current}
+      />
+    </>
+  );
+};
 
 /* ──────────────────────────────────────────────────────────────
    Props
@@ -35,6 +73,7 @@ const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({ scrollContainer }
     slice(scrollYProgress, i / sceneCount, (i + 1) / sceneCount)
   );
   const [s0, s1, s2, s3] = segments;
+  const introSection = slice(scrollYProgress, 0, 0.5);
 
   // Optionally prevent scrolling into the next segment until the current one completes
   useMotionValueEvent(scrollYProgress, "change", (v) => {
@@ -57,9 +96,11 @@ const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({ scrollContainer }
 
   return (
     <>
-      <StoryboardSection progress={s0}>{(p) => <IntroShuffle progress={p} />}</StoryboardSection>
-
-      <StoryboardSection progress={s1}>{(p) => <SpreadReveal progress={p} />}</StoryboardSection>
+      <StoryboardSection progress={introSection} height={400}>
+        {() => (
+          <IntroSequence shuffleProgress={s0} revealProgress={s1} />
+        )}
+      </StoryboardSection>
 
       <StoryboardSection progress={s2}>{(p) => <ProjectDeck progress={p} />}</StoryboardSection>
 

--- a/src/components/Projects/SpreadReveal.tsx
+++ b/src/components/Projects/SpreadReveal.tsx
@@ -1,61 +1,45 @@
-import React, { useRef } from "react";
-import { MotionValue, motionValue } from "framer-motion";
+import React from "react";
+import { MotionValue } from "framer-motion";
 import { useFrame, useThree } from "@react-three/fiber";
 import * as THREE from "three";
-import Card3D from "./Card3D";
-import backPlaceholder  from "./textures/backtemp.png";
 
 interface SpreadRevealProps {
   progress: MotionValue<number>;
-  cards?: { front: string; back: string; elementScale?: number }[];
+  cardRefs: React.MutableRefObject<THREE.Group[]>;
+  flipVals: MotionValue<number>[];
   baseRadius?: number;
 }
 
 
-const colors = ["red", "blue", "green", "yellow", "purple", "pink"];
-const colorTex = (c: string) =>
-  `data:image/svg+xml;utf8,<svg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 1 1'><rect width='1' height='1' fill='${encodeURIComponent(
-    c
-  )}'/></svg>`;
-
-const defaultCards = Array.from({ length: 6 }, (_, i) => ({
-  front: colorTex(colors[i % colors.length]),
-  back: backPlaceholder,
-  elementScale: 1.2 + i * 0.05,
-}));
 
 const SpreadReveal: React.FC<SpreadRevealProps> = ({
   progress,
-  cards = defaultCards,
+  cardRefs,
+  flipVals,
   baseRadius,
 }) => {
   const { viewport } = useThree();
   const ringRadius = baseRadius ?? viewport.width * 0.75;
   const cardSpacing = viewport.width * 0.15;
-  const refs = useRef<THREE.Group[]>([]);
-  const flipVals = useRef<MotionValue<number>[]>([]);
-
-  if (flipVals.current.length !== cards.length) {
-    flipVals.current = cards.map(() => motionValue(0));
-  }
+  const cardCount = cardRefs.current.length;
 
   useFrame(() => {
     const t = progress.get();
     const rowPhase = Math.min(t / 0.5, 1);
     const circlePhase = t > 0.5 ? (t - 0.5) / 0.5 : 0;
-    const step = 1 / cards.length;
+    const step = 1 / cardCount;
 
-    cards.forEach((_, i) => {
-      const g = refs.current[i];
-      if (!g) return;
+    for (let i = 0; i < cardCount; i++) {
+      const g = cardRefs.current[i];
+      if (!g) continue;
       const start = step * i;
       const localRow = THREE.MathUtils.clamp((rowPhase - start) / step, 0, 1);
       const localCircle = THREE.MathUtils.clamp((circlePhase - start) / step, 0, 1);
 
-      const xRow = (i - (cards.length - 1) / 2) * cardSpacing;
-      g.position.set(xRow * localRow, 0, 0);
+      const xRow = (i - (cardCount - 1) / 2) * cardSpacing;
+      g.position.set(xRow * localRow, 0, g.position.z);
 
-      const angle = (i / cards.length) * Math.PI * 2;
+      const angle = (i / cardCount) * Math.PI * 2;
       const xCircle = Math.cos(angle) * ringRadius * localCircle;
       const yCircle = Math.sin(angle) * ringRadius * localCircle;
       g.position.x = THREE.MathUtils.lerp(g.position.x, xCircle, localCircle);
@@ -63,25 +47,11 @@ const SpreadReveal: React.FC<SpreadRevealProps> = ({
       g.rotation.z = angle * localCircle;
 
       const cardFlip = Math.max(localRow, localCircle);
-      flipVals.current[i].set(cardFlip);
-    });
+      flipVals[i]?.set(cardFlip);
+    }
   });
 
-  return (
-    <>
-      {cards.map((c, i) => (
-        <group key={i} ref={(el) => (refs.current[i] = el!)}>
-          <Card3D
-            frontSrc={c.front}
-            backSrc={c.back}
-            pop={progress}
-            popScale={c.elementScale}
-            flip={flipVals.current[i]}
-          />
-        </group>
-      ))}
-    </>
-  );
+  return null;
 };
 
 export default SpreadReveal;

--- a/src/components/Projects/StoryboardSection.tsx
+++ b/src/components/Projects/StoryboardSection.tsx
@@ -7,15 +7,18 @@ import * as THREE from "three";
 interface StoryboardSectionProps {
   /** Scene progress provided by ProjectStoryboard */
   progress: MotionValue<number>;
+  /** Height in viewport units (default 200) */
+  height?: number;
   children: (progress: MotionValue<number>) => React.ReactNode;
 }
 
 const StoryboardSection: React.FC<StoryboardSectionProps> = ({
   progress,
+  height = 200,
   children,
 }) => {
   return (
-    <section className="h-[200vh]">
+    <section style={{ height: `${height}vh` }}>
       {/*
         Sticky wrapper stays fixed while this section's scroll progress
         is between 0 and 1. Once scrollYProgress reaches 1, the wrapper


### PR DESCRIPTION
## Summary
- pass deck refs into IntroShuffle and SpreadReveal instead of creating decks per scene
- manage a single IntroDeck instance in a new IntroSequence wrapper
- combine first two storyboard segments into one section that holds IntroDeck
- make StoryboardSection height configurable

## Testing
- `npx tsc -p tsconfig.json`
- `npm run build` *(fails: esbuild binary missing)*

------
https://chatgpt.com/codex/tasks/task_e_686ebeb83cd483318580d4569d835538