### PR TITLE
Fix Three.js color space property

### DIFF
--- a/src/components/Projects/StoryboardSection.tsx
+++ b/src/components/Projects/StoryboardSection.tsx
@@ -32,7 +32,8 @@ const StoryboardSection: React.FC<StoryboardSectionProps> = ({
           shadows
           gl={{ preserveDrawingBuffer: false }}
           onCreated={({ gl }) => {
-            (gl as any).colorSpace = THREE.SRGBColorSpace;
+            // Use the outputColorSpace property introduced in three.js r156
+            (gl as any).outputColorSpace = THREE.SRGBColorSpace;
             THREE.ColorManagement.enabled = true;
           }}
         >


### PR DESCRIPTION
## Summary
- set `outputColorSpace` on renderer instead of deprecated `colorSpace`

## Testing
- `npm run build` *(fails: platform-specific esbuild binary error)*

------
https://chatgpt.com/codex/tasks/task_e_686ec319a45883318716447f8f90087c