### PR TITLE
Restore per-section scrolling

### DIFF
--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -1,5 +1,5 @@
 import React, { RefObject, useRef } from "react";
-import { MotionValue, useScroll, useTransform, useMotionValueEvent, motionValue } from "framer-motion";
+import { MotionValue, useTransform, motionValue } from "framer-motion";
 import StoryboardSection from "./StoryboardSection";
 
 import IntroDeck from "./IntroDeck";
@@ -58,55 +58,26 @@ export interface ProjectStoryboardProps {
 /* ──────────────────────────────────────────────────────────────
    Component
    ────────────────────────────────────────────────────────────── */
-const slice = (
-  mv: MotionValue<number>,
-  start: number,
-  end: number
-) => useTransform(mv, [start, end], [0, 1]);
-
-const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({ scrollContainer }) => {
-  // Track the scroll progress of the entire storyboard container
-  const { scrollYProgress } = useScroll({ container: scrollContainer, layoutEffect: false });
-
-  // Break global progress into equal segments for each scene
-  const segments = Array.from({ length: sceneCount }, (_, i) =>
-    slice(scrollYProgress, i / sceneCount, (i + 1) / sceneCount)
-  );
-  const [s0, s1, s2, s3] = segments;
-  const introSection = slice(scrollYProgress, 0, 0.5);
-
-  // Optionally prevent scrolling into the next segment until the current one completes
-  useMotionValueEvent(scrollYProgress, "change", (v) => {
-    const el = scrollContainer.current;
-    if (!el) return;
-    const total = el.scrollHeight - el.clientHeight;
-    for (let i = 0; i < segments.length; i++) {
-      const start = i / sceneCount;
-      const end = (i + 1) / sceneCount;
-      const local = segments[i].get();
-      if (v > end && local < 1) {
-        el.scrollTop = end * total;
-        return;
-      } else if (v < start && local > 0) {
-        el.scrollTop = start * total;
-        return;
-      }
-    }
-  });
-
-  return (
-    <>
-      <StoryboardSection progress={introSection} height={400}>
-        {() => (
-          <IntroSequence shuffleProgress={s0} revealProgress={s1} />
-        )}
-      </StoryboardSection>
-
-      <StoryboardSection progress={s2}>{(p) => <ProjectDeck progress={p} />}</StoryboardSection>
-
-      <StoryboardSection progress={s3}>{(p) => <ProjectCardInfo progress={p} />}</StoryboardSection>
-    </>
-  );
+const IntroWrapper: React.FC<{ progress: MotionValue<number> }> = ({ progress }) => {
+  const shuffleProgress = useTransform(progress, [0, 0.5], [0, 1], { clamp: true });
+  const revealProgress = useTransform(progress, [0.5, 1], [0, 1], { clamp: true });
+  return <IntroSequence shuffleProgress={shuffleProgress} revealProgress={revealProgress} />;
 };
+
+const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({ scrollContainer }) => (
+  <>
+    <StoryboardSection container={scrollContainer}>
+      {(p) => <IntroWrapper progress={p} />}
+    </StoryboardSection>
+
+    <StoryboardSection container={scrollContainer}>
+      {(p) => <ProjectDeck progress={p} />}
+    </StoryboardSection>
+
+    <StoryboardSection container={scrollContainer}>
+      {(p) => <ProjectCardInfo progress={p} />}
+    </StoryboardSection>
+  </>
+);
 
 export default ProjectStoryboard;

--- a/src/components/Projects/StoryboardSection.tsx
+++ b/src/components/Projects/StoryboardSection.tsx
@@ -1,25 +1,27 @@
-import React, { Suspense } from "react";
+import React, { Suspense, useRef } from "react";
 import { Canvas } from "@react-three/fiber";
 import { AdaptiveDpr, PerspectiveCamera, Environment } from "@react-three/drei";
-import { MotionValue, useTransform } from "framer-motion";
+import { MotionValue, useScroll } from "framer-motion";
 import * as THREE from "three";
 
 interface StoryboardSectionProps {
-  /** Scene progress provided by ProjectStoryboard */
-  progress: MotionValue<number>;
-  /** Height in viewport units (default 200) */
-  height?: number;
+  container: React.RefObject<HTMLElement>;
   children: (progress: MotionValue<number>) => React.ReactNode;
 }
 
 const StoryboardSection: React.FC<StoryboardSectionProps> = ({
-  progress,
-  height = 200,
+  container,
   children,
 }) => {
-  const innerProgress = useTransform(progress, [0, 0.5], [0, 1], { clamp: true });
+  const ref = useRef<HTMLElement>(null);
+  const { scrollYProgress } = useScroll({
+    container,
+    target: ref,
+    offset: ["start start", "end start"],
+    layoutEffect: false,
+  });
   return (
-    <section style={{ height: `${height}vh` }}>
+    <section ref={ref} className="h-[200vh]">
       {/*
         Sticky wrapper stays fixed while this section's scroll progress
         is between 0 and 1. Once scrollYProgress reaches 1, the wrapper
@@ -44,7 +46,7 @@ const StoryboardSection: React.FC<StoryboardSectionProps> = ({
           <Suspense fallback={null}>
             <Environment preset="sunset" />
           </Suspense>
-          <group scale={1.4}>{children(innerProgress)}</group>
+          <group scale={1.4}>{children(scrollYProgress)}</group>
         </Canvas>
       </div>
     </section>

--- a/src/pages/ProjectsPage.tsx
+++ b/src/pages/ProjectsPage.tsx
@@ -1,19 +1,16 @@
 // src/pages/ProjectsPage.tsx
 import React, { useRef } from "react";
-import ProjectStoryboard, { sceneCount } from "../components/Projects/ProjectStoryboard";
+import ProjectStoryboard from "../components/Projects/ProjectStoryboard";
 import Footer from "../components/Footer";
 
 const ProjectsPage: React.FC = () => {
   const scrollRef = useRef<HTMLDivElement>(null);
-  const containerHeight = `${sceneCount * 100}vh`;
 
   return (
     <>
       <div
         ref={scrollRef}
-        className="relative w-screen overflow-y-auto overflow-x-hidden bg-white"
-
-        style={{ height: "800vh" }}
+        className="relative w-screen min-h-screen overflow-y-auto overflow-x-hidden bg-white"
       >
         <ProjectStoryboard scrollContainer={scrollRef} />
       </div>


### PR DESCRIPTION
## Summary
- track scroll progress per `StoryboardSection` again
- use per-section progress in `ProjectStoryboard`
- make the projects page grow with content

## Testing
- `npm run build` *(fails: esbuild platform mismatch)*

------
https://chatgpt.com/codex/tasks/task_e_686ec3183828833186fe58ab4c8fdf12