### PR TITLE
Fix overscroll logic in storyboard

### DIFF
--- a/src/components/Projects/ProjectStoryboard.tsx
+++ b/src/components/Projects/ProjectStoryboard.tsx
@@ -1,5 +1,11 @@
 import React, { RefObject, useRef } from "react";
-import { MotionValue, useTransform, motionValue } from "framer-motion";
+import {
+  MotionValue,
+  useScroll,
+  useTransform,
+  useMotionValueEvent,
+  motionValue,
+} from "framer-motion";
 import StoryboardSection from "./StoryboardSection";
 
 import IntroDeck from "./IntroDeck";
@@ -47,37 +53,60 @@ const IntroSequence: React.FC<IntroSequenceProps> = ({
   );
 };
 
-/* ──────────────────────────────────────────────────────────────
-   Props
-   ────────────────────────────────────────────────────────────── */
 export interface ProjectStoryboardProps {
   /** The scrollable element that <StoryboardSection> will observe */
   scrollContainer: RefObject<HTMLElement>;
 }
 
-/* ──────────────────────────────────────────────────────────────
-   Component
-   ────────────────────────────────────────────────────────────── */
-const IntroWrapper: React.FC<{ progress: MotionValue<number> }> = ({ progress }) => {
-  const shuffleProgress = useTransform(progress, [0, 0.5], [0, 1], { clamp: true });
-  const revealProgress = useTransform(progress, [0.5, 1], [0, 1], { clamp: true });
-  return <IntroSequence shuffleProgress={shuffleProgress} revealProgress={revealProgress} />;
+const slice = (
+  mv: MotionValue<number>,
+  start: number,
+  end: number
+) => useTransform(mv, [start, end], [0, 1], { clamp: true });
+
+const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({ scrollContainer }) => {
+  // Track the scroll progress of the entire storyboard container
+  const { scrollYProgress } = useScroll({ container: scrollContainer, layoutEffect: false });
+
+  // Break global progress into equal segments for each scene
+  const segments = Array.from({ length: sceneCount }, (_, i) =>
+    slice(scrollYProgress, i / sceneCount, (i + 1) / sceneCount)
+  );
+  const [s0, s1, s2, s3] = segments;
+  const introSection = slice(scrollYProgress, 0, 0.5);
+
+  // Optionally prevent scrolling into the next segment until the current one completes
+  useMotionValueEvent(scrollYProgress, "change", (v) => {
+    const el = scrollContainer.current;
+    if (!el) return;
+    const total = el.scrollHeight - el.clientHeight;
+    for (let i = 0; i < segments.length; i++) {
+      const start = i / sceneCount;
+      const end = (i + 1) / sceneCount;
+      let local = (v - start) / (end - start);
+      if (local < 0) local = 0;
+      else if (local > 1) local = 1;
+      if (v > end && local < 1) {
+        el.scrollTop = end * total;
+        return;
+      } else if (v < start && local > 0) {
+        el.scrollTop = start * total;
+        return;
+      }
+    }
+  });
+
+  return (
+    <>
+      <StoryboardSection progress={introSection} height={400}>
+        {() => <IntroSequence shuffleProgress={s0} revealProgress={s1} />}
+      </StoryboardSection>
+
+      <StoryboardSection progress={s2}>{(p) => <ProjectDeck progress={p} />}</StoryboardSection>
+
+      <StoryboardSection progress={s3}>{(p) => <ProjectCardInfo progress={p} />}</StoryboardSection>
+    </>
+  );
 };
-
-const ProjectStoryboard: React.FC<ProjectStoryboardProps> = ({ scrollContainer }) => (
-  <>
-    <StoryboardSection container={scrollContainer}>
-      {(p) => <IntroWrapper progress={p} />}
-    </StoryboardSection>
-
-    <StoryboardSection container={scrollContainer}>
-      {(p) => <ProjectDeck progress={p} />}
-    </StoryboardSection>
-
-    <StoryboardSection container={scrollContainer}>
-      {(p) => <ProjectCardInfo progress={p} />}
-    </StoryboardSection>
-  </>
-);
 
 export default ProjectStoryboard;

--- a/src/components/Projects/StoryboardSection.tsx
+++ b/src/components/Projects/StoryboardSection.tsx
@@ -1,27 +1,24 @@
-import React, { Suspense, useRef } from "react";
+import React, { Suspense } from "react";
 import { Canvas } from "@react-three/fiber";
 import { AdaptiveDpr, PerspectiveCamera, Environment } from "@react-three/drei";
-import { MotionValue, useScroll } from "framer-motion";
+import { MotionValue } from "framer-motion";
 import * as THREE from "three";
 
 interface StoryboardSectionProps {
-  container: React.RefObject<HTMLElement>;
+  /** Scene progress provided by ProjectStoryboard */
+  progress: MotionValue<number>;
+  /** Height in viewport units (default 200) */
+  height?: number;
   children: (progress: MotionValue<number>) => React.ReactNode;
 }
 
 const StoryboardSection: React.FC<StoryboardSectionProps> = ({
-  container,
+  progress,
+  height = 200,
   children,
 }) => {
-  const ref = useRef<HTMLElement>(null);
-  const { scrollYProgress } = useScroll({
-    container,
-    target: ref,
-    offset: ["start start", "end start"],
-    layoutEffect: false,
-  });
   return (
-    <section ref={ref} className="h-[200vh]">
+    <section style={{ height: `${height}vh` }}>
       {/*
         Sticky wrapper stays fixed while this section's scroll progress
         is between 0 and 1. Once scrollYProgress reaches 1, the wrapper
@@ -47,7 +44,7 @@ const StoryboardSection: React.FC<StoryboardSectionProps> = ({
           <Suspense fallback={null}>
             <Environment preset="sunset" />
           </Suspense>
-          <group scale={1.4}>{children(scrollYProgress)}</group>
+          <group scale={1.4}>{children(progress)}</group>
         </Canvas>
       </div>
     </section>


### PR DESCRIPTION
## Summary
- clamp slice MotionValues when segmenting global progress
- compute local progress manually to enforce scroll locking
- simplify StoryboardSection to accept progress prop

## Testing
- `./node_modules/.bin/tsc --noEmit`
- `npm run dev` *(fails: platform mismatch for esbuild)*

------
https://chatgpt.com/codex/tasks/task_e_686ed06708e88331965a08fec84c4593